### PR TITLE
Added fetch_and and fetch_or to __atomic_base

### DIFF
--- a/include/simt/atomic
+++ b/include/simt/atomic
@@ -128,6 +128,21 @@ struct atomic
         return details::__atomic_fetch_min_simt(&this->__a_.__a_value, __op,
                                               __m, details::__scope_tag<_Sco>());
     }
+
+    __host__ __device__
+    _Tp fetch_or(const _Tp & __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    {
+        return details::__atomic_fetch_or_simt(&this->__a.__a_value, __op,
+                                               __m, details::__scope_tag<_Sco>());
+    }
+
+    __host__ __device__
+    _Tp fetch_and(const _Tp & __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+    {
+        return details::__atomic_fetch_and_simt(&this->__a.__a_value, __op,
+                                               __m, details::__scope_tag<_Sco>());
+    }
+
 };
 
 // atomic<T*>


### PR DESCRIPTION
Adding two methods to atomic base to allow accessing the atomic bitwise and/or functionality already present in the code